### PR TITLE
Add global-mode to use-package example config

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Praise the sun.
   ((change-major-mode after-revert ediff-prepare-buffer) . turn-on-solaire-mode)
   (minibuffer-setup . solaire-mode-in-minibuffer)
   :config
+  (solaire-global-mode +1)
   (solaire-mode-swap-bg))
 ```
 


### PR DESCRIPTION
At least in my setup (spacemacs 0.300 on emacs 26.1), I could not reproduce the effects of the first config example without use-package if I just picked the provided use-package alternative. Then I noticed that they are not exactly the same.

Adding `solaire-global-mode` to the example so that others do not get confused with the same mistake.