### PR TITLE
Add stimmung-themes to list of supported themes

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ The only (known) themes to support solaire-mode are:
 + [modus-themes]
 + [parchment]
 + [spacemacs-theme]
++ [stimmung-themes]
 + [vscode-dark-plus-theme]
 + [wilmersdorf-theme]
 
@@ -142,5 +143,6 @@ If you know of more, feel free to PR them.
 [nano-theme]: https://github.com/404cn/nano-theme.el
 [parchment]: https://github.com/ajgrf/parchment
 [spacemacs-theme]: https://github.com/nashamri/spacemacs-theme
+[stimmung-themes]: https://github.com/motform/stimmung-themes
 [vscode-dark-plus-theme]: https://github.com/ianpan870102/vscode-dark-plus-emacs-theme
 [wilmersdorf-theme]: https://github.com/ianpan870102/wilmersdorf-emacs-theme


### PR DESCRIPTION
I just added out-of-the-box support for solaire-mode, so I thought it would be nice to add it to the list! See the [request issue](https://github.com/motform/stimmung-themes/issues/5) for screenshots and the such.